### PR TITLE
remove docHost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 /.nb-gradle/
 */target/
 */node_modules/
+.DS_Store

--- a/grpc-swagger-web/src/main/java/io/grpc/grpcswagger/controller/GrpcController.java
+++ b/grpc-swagger-web/src/main/java/io/grpc/grpcswagger/controller/GrpcController.java
@@ -16,6 +16,7 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -67,8 +68,9 @@ public class GrpcController {
     }
 
     @RequestMapping("/v2/api-docs")
-    public Object groupResponse(@RequestParam("service") String service) {
-        return documentService.getDocumentation(service);
+    public Object groupResponse(@RequestParam("service") String service, HttpServletRequest httpServletRequest) {
+        String apiHost = httpServletRequest.getHeader("Host");
+        return documentService.getDocumentation(service, apiHost);
     }
 
     @RequestMapping("/{rawFullMethodName}")

--- a/grpc-swagger-web/src/main/java/io/grpc/grpcswagger/service/DocumentService.java
+++ b/grpc-swagger-web/src/main/java/io/grpc/grpcswagger/service/DocumentService.java
@@ -13,13 +13,10 @@ import io.grpc.grpcswagger.openapi.v2.SwaggerV2Documentation;
 @Service
 public class DocumentService {
 
-    @Value("${docHost}")
-    private String docHost;
-
-    public SwaggerV2Documentation getDocumentation(String service) {
+    public SwaggerV2Documentation getDocumentation(String service, String apiHost) {
         SwaggerV2Documentation swaggerV2Documentation = DocumentRegistry.getInstance().get(service);
         if (swaggerV2Documentation != null) {
-            swaggerV2Documentation.setHost(docHost);
+            swaggerV2Documentation.setHost(apiHost);
         }
         return swaggerV2Documentation;
     }

--- a/grpc-swagger-web/src/main/resources/application-production.properties
+++ b/grpc-swagger-web/src/main/resources/application-production.properties
@@ -1,3 +1,2 @@
 server.port=8080
 logging.level.root=info
-docHost=localhost

--- a/grpc-swagger-web/src/main/resources/application.properties
+++ b/grpc-swagger-web/src/main/resources/application.properties
@@ -1,3 +1,2 @@
 server.port=8080
 logging.level.root=info
-docHost=localhost:8080


### PR DESCRIPTION
Motivation:
之前我们用docHost来确定执行方法时调用哪个api，现在看来这个是冗余的，可以通过用于输入的/v2-api-docs接口的请求中获取到